### PR TITLE
Add useAlternateBackground in UILabeledRoundButtonVC (thx Muirey)

### DIFF
--- a/Headers/ControlCenterUIKit/CCUILabeledRoundButtonViewController.h
+++ b/Headers/ControlCenterUIKit/CCUILabeledRoundButtonViewController.h
@@ -40,6 +40,7 @@
 @property (assign,nonatomic) BOOL toggleStateOnTap;						//@synthesize toggleStateOnTap=_toggleStateOnTap - In the implementation block
 @property (assign,getter=isEnabled,nonatomic) BOOL enabled;					//@synthesize enabled=_enabled - In the implementation block
 @property (assign,getter=isInoperative,nonatomic) BOOL inoperative;				//@synthesize inoperative=_inoperative - In the implementation block
+@property (assign,nonatomic) BOOL useAlternateBackground;
 - (UIControl *)button;
 - (void)setTitle:(NSString *)arg1;
 - (void)loadView;


### PR DESCRIPTION
useAlternateBackground is a property needed in CCUILabeledRoundButtonViewController, Muirey is using it in his PowerModule. It will be nice to have it here too.